### PR TITLE
Add first ATL06 support.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SpaceLiDAR"
 uuid = "29bf0bfc-420f-4fa5-b441-811fd9e6e11d"
 authors = ["Maarten Pronk", "Deltares"]
-version = "0.1.4"
+version = "0.1.5"
 
 [deps]
 AWSCore = "4f1ea46c-232b-54a6-9b17-cc2d0f3e6598"

--- a/README.md
+++ b/README.md
@@ -15,9 +15,10 @@ Currently supports the following data products:
 | data product | User Guide (UG) | Algorithm Theoretical Basis Document (ATBD)|
 |--- |--- |--- |
 | ICESat GLAH14 v34 | [UG](https://nsidc.org/sites/nsidc.org/files/MULTI-GLAH01-V033-V034-UserGuide.pdf) | [ATBD](https://eospso.nasa.gov/sites/default/files/atbd/ATBD-GLAS-02.pdf) | 
- | ICESat-2 ATL03 v4 | [UG](https://nsidc.org/sites/nsidc.org/files/ATL03-V004-UserGuide.pdf)  | [ATBD](https://icesat-2.gsfc.nasa.gov/sites/default/files/page_files/ICESat2_ATL03_ATBD_r004.pdf) | 
- | ICESat-2 ATL08 v4 | [UG](https://nsidc.org/sites/nsidc.org/files/ATL08-V004-UserGuide.pdf) | [ATBD](https://icesat-2.gsfc.nasa.gov/sites/default/files/page_files/ICESat2_ATL08_ATBD_r004.pdf) | 
- | ICESat-2 ATL12 v4 | [UG](https://nsidc.org/sites/nsidc.org/files/ATL12-V004-UserGuide.pdf) | [ATBD](https://icesat-2.gsfc.nasa.gov/sites/default/files/page_files/ICESat2_ATL12_ATBD_r004.pdf) | 
+ | ICESat-2 ATL03 v5 | [UG](https://nsidc.org/sites/nsidc.org/files/ATL03-V005-UserGuide.pdf)  | [ATBD](https://icesat-2.gsfc.nasa.gov/sites/default/files/page_files/ICESat2_ATL03_ATBD_r005.pdf) | 
+ | ICESat-2 ATL06 v5 | [UG](https://nsidc.org/sites/nsidc.org/files/ATL03-V005-UserGuide.pdf)  | [ATBD](https://icesat-2.gsfc.nasa.gov/sites/default/files/page_files/ICESat2_ATL06_ATBD_r005.pdf) | 
+ | ICESat-2 ATL08 v5 | [UG](https://nsidc.org/sites/nsidc.org/files/ATL08-V005-UserGuide.pdf) | [ATBD](https://icesat-2.gsfc.nasa.gov/sites/default/files/page_files/ICESat2_ATL08_ATBD_r005.pdf) | 
+ | ICESat-2 ATL12 v5 | [UG](https://nsidc.org/sites/nsidc.org/files/ATL12-V005-UserGuide.pdf) | [ATBD](https://icesat-2.gsfc.nasa.gov/sites/default/files/page_files/ICESat2_ATL12_ATBD_r005.pdf) | 
  | GEDI L2A v2 | [UG](https://lpdaac.usgs.gov/documents/998/GEDI02_User_Guide_V2.pdf) | [ATBD](https://lpdaac.usgs.gov/documents/581/GEDI_WF_ATBD_v1.0.pdf) | 
 
 For a quick overview, see the FOSS4G Pluto notebook [here](https://www.evetion.nl/SpaceLiDAR.jl/dev/tutorial/foss4g_2021.jl.html)

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -14,12 +14,12 @@ Currently supports the following data products:
 
 | data product | User Guide (UG) | Algorithm Theoretical Basis Document (ATBD)|
 |--- |--- |--- |
-| ICESat GLAH14 v34 | [UG](https://nsidc.org/sites/nsidc.org/files/MULTI-GLAH01-V033-V034-UserGuide.pdf) | [ATBD](https://eospso.nasa.gov/sites/default/files/atbd/ATBD-GLAS-02.pdf) | 
- | ICESat-2 ATL03 v4 | [UG](https://nsidc.org/sites/nsidc.org/files/ATL03-V004-UserGuide.pdf)  | [ATBD](https://icesat-2.gsfc.nasa.gov/sites/default/files/page_files/ICESat2_ATL03_ATBD_r004.pdf) | 
- | ICESat-2 ATL08 v4 | [UG](https://nsidc.org/sites/nsidc.org/files/ATL08-V004-UserGuide.pdf) | [ATBD](https://icesat-2.gsfc.nasa.gov/sites/default/files/page_files/ICESat2_ATL08_ATBD_r004.pdf) | 
- | ICESat-2 ATL12 v4 | [UG](https://nsidc.org/sites/nsidc.org/files/ATL12-V004-UserGuide.pdf) | [ATBD](https://icesat-2.gsfc.nasa.gov/sites/default/files/page_files/ICESat2_ATL12_ATBD_r004.pdf) | 
- | GEDI L2A v2 | [UG](https://lpdaac.usgs.gov/documents/998/GEDI02_User_Guide_V2.pdf) | [ATBD](https://lpdaac.usgs.gov/documents/581/GEDI_WF_ATBD_v1.0.pdf) | 
-
+| ICESat GLAH14 v34 | [UG](https://nsidc.org/sites/nsidc.org/files/MULTI-GLAH01-V033-V034-UserGuide.pdf) | [ATBD](https://eospso.nasa.gov/sites/default/files/atbd/ATBD-GLAS-02.pdf) |
+ | ICESat-2 ATL03 v5 | [UG](https://nsidc.org/sites/nsidc.org/files/ATL03-V005-UserGuide.pdf)  | [ATBD](https://icesat-2.gsfc.nasa.gov/sites/default/files/page_files/ICESat2_ATL03_ATBD_r005.pdf) |
+ | ICESat-2 ATL06 v5 | [UG](https://nsidc.org/sites/nsidc.org/files/ATL03-V005-UserGuide.pdf)  | [ATBD](https://icesat-2.gsfc.nasa.gov/sites/default/files/page_files/ICESat2_ATL06_ATBD_r005.pdf) |
+ | ICESat-2 ATL08 v5 | [UG](https://nsidc.org/sites/nsidc.org/files/ATL08-V005-UserGuide.pdf) | [ATBD](https://icesat-2.gsfc.nasa.gov/sites/default/files/page_files/ICESat2_ATL08_ATBD_r005.pdf) |
+ | ICESat-2 ATL12 v5 | [UG](https://nsidc.org/sites/nsidc.org/files/ATL12-V005-UserGuide.pdf) | [ATBD](https://icesat-2.gsfc.nasa.gov/sites/default/files/page_files/ICESat2_ATL12_ATBD_r005.pdf) |
+ | GEDI L2A v2 | [UG](https://lpdaac.usgs.gov/documents/998/GEDI02_User_Guide_V2.pdf) | [ATBD](https://lpdaac.usgs.gov/documents/581/GEDI_WF_ATBD_v1.0.pdf) |
 
 For a quick overview, see the FOSS4G Pluto notebook [here](tutorial/foss4g_2021.jl.html)
 

--- a/src/ICESat-2/ATL06.jl
+++ b/src/ICESat-2/ATL06.jl
@@ -35,6 +35,7 @@ function points(
     t = file["$track/land_ice_segments/delta_time"][1:step:end]::Vector{Float64}
     q = file["$track/land_ice_segments/atl06_quality_summary"][1:step:end]::Vector{Int8}
     dem = file["$track/land_ice_segments/dem/dem_h"][1:step:end]::Vector{Float32}
+    spot_number = attrs(file["$track"])["atlas_spot_number"]::String
     times = unix2datetime.(t .+ t_offset)
 
     nt = (;
@@ -46,6 +47,7 @@ function points(
         q = q,
         track = Fill(track, length(times)),
         power = Fill(power, length(times)),
+        trackid = Fill(parse(Int8, spot_number), length(times)),
         reference = dem,
     )
     return nt

--- a/src/ICESat-2/ATL06.jl
+++ b/src/ICESat-2/ATL06.jl
@@ -1,3 +1,24 @@
+"""
+    points(g::ICESat2_Granule{:ATL06})
+
+Retrieve the points for a given ATL06 (Land Ice) granule as a list of namedtuples, one for each beam.
+The names of the tuples are based on the following fields:
+
+| Column           | Field                                   | Description                                       |
+|------------------|-----------------------------------------|---------------------------------------------------|
+| `longitude`        | `land_ice_segments/longitude`             | Longitude of segment center, WGS84, East=+        |
+| `latitude`         | `land_ice_segments/latitude`              | Latitude of segment center, WGS84, North=+        |
+| `height`           | `land_ice_segments/h_li`                  | Standard land-ice segment height                  |
+| `height_error`     | `land_ice_segments/sigma_geo_h`           | Total vertical geolocation error                  |
+| `datetime`         | `land_ice_segments/delta_time`            | + `ancillary_data/atlas_sdp_gps_epoch` + `gps_offset` |
+| `quality`          | `land_ice_segments/atl06_quality_summary` | Boolean flag indicating the best-quality subset   |
+| `track`            | `gt1l` - `gt3r` groups                    | -                                                 |
+| `power`            | `-`                                       | "strong" or "weak" laser power                    |
+| `detector_id`      | `atlas_spot_number attribute`             | -                                                 |
+| `height_reference` | `land_ice_segments/dem/dem_h`             | Height of the (best available) DEM                |
+
+You can combine the output in a `DataFrame` with `reduce(vcat, DataFrame.(points(g)))`.
+"""
 function points(
     granule::ICESat2_Granule{:ATL06};
     tracks = icesat2_tracks,
@@ -12,13 +33,15 @@ function points(
             power = track_power(orientation, track)
             if in(track, keys(file)) && in("land_ice_segments", keys(file[track]))
                 track_nt = points(granule, file, track, power, t_offset, step)
-                track_nt.z[track_nt.z.==fill_value] .= NaN
+                track_nt.height[track_nt.height.==fill_value] .= NaN
+                track_nt.height_uncertainty[track_nt.height_uncertainty.==fill_value] .= NaN
                 push!(dfs, track_nt)
             end
         end
     end
     return dfs
 end
+
 
 function points(
     ::ICESat2_Granule{:ATL06},
@@ -29,7 +52,7 @@ function points(
     step = 1,
 )
     z = file["$track/land_ice_segments/h_li"][1:step:end]::Vector{Float32}
-    zu = file["$track/land_ice_segments/h_li_sigma"][1:step:end]::Vector{Float32}
+    zu = file["$track/land_ice_segments/sigma_geo_h"][1:step:end]::Vector{Float32}
     x = file["$track/land_ice_segments/longitude"][1:step:end]::Vector{Float64}
     y = file["$track/land_ice_segments/latitude"][1:step:end]::Vector{Float64}
     t = file["$track/land_ice_segments/delta_time"][1:step:end]::Vector{Float64}
@@ -39,16 +62,16 @@ function points(
     times = unix2datetime.(t .+ t_offset)
 
     nt = (;
-        x = x,
-        y = y,
-        z = z,
-        u = zu,
-        t = times,
-        q = q,
+        longitude = x,
+        latitude = y,
+        height = z,
+        height_uncertainty = zu,
+        datetime = times,
+        quality = .!Bool.(q),
         track = Fill(track, length(times)),
         power = Fill(power, length(times)),
-        trackid = Fill(parse(Int8, spot_number), length(times)),
-        reference = dem,
+        detector_id = Fill(parse(Int8, spot_number), length(times)),
+        height_reference = dem,
     )
     return nt
 end

--- a/src/ICESat-2/ATL06.jl
+++ b/src/ICESat-2/ATL06.jl
@@ -34,7 +34,7 @@ function points(
             if in(track, keys(file)) && in("land_ice_segments", keys(file[track]))
                 track_nt = points(granule, file, track, power, t_offset, step)
                 track_nt.height[track_nt.height.==fill_value] .= NaN
-                track_nt.height_uncertainty[track_nt.height_uncertainty.==fill_value] .= NaN
+                track_nt.height_error[track_nt.height_error.==fill_value] .= NaN
                 push!(dfs, track_nt)
             end
         end
@@ -65,7 +65,7 @@ function points(
         longitude = x,
         latitude = y,
         height = z,
-        height_uncertainty = zu,
+        height_error = zu,
         datetime = times,
         quality = .!Bool.(q),
         track = Fill(track, length(times)),

--- a/src/ICESat-2/ATL06.jl
+++ b/src/ICESat-2/ATL06.jl
@@ -1,0 +1,52 @@
+function points(
+    granule::ICESat2_Granule{:ATL06};
+    tracks = icesat2_tracks,
+    step = 1,
+)
+    dfs = Vector{NamedTuple}()
+    HDF5.h5open(granule.url, "r") do file
+        t_offset = read(file, "ancillary_data/atlas_sdp_gps_epoch")[1]::Float64 + gps_offset
+        orientation = read(file, "orbit_info/sc_orient")[1]::Int8
+
+        for (i, track) in enumerate(tracks)
+            power = track_power(orientation, track)
+            if in(track, keys(file)) && in("land_ice_segments", keys(file[track]))
+                track_nt = points(granule, file, track, power, t_offset, step)
+                track_nt.z[track_nt.z.==fill_value] .= NaN
+                push!(dfs, track_nt)
+            end
+        end
+    end
+    return dfs
+end
+
+function points(
+    ::ICESat2_Granule{:ATL06},
+    file::HDF5.H5DataStore,
+    track::AbstractString,
+    power::AbstractString,
+    t_offset::Float64,
+    step = 1,
+)
+    z = file["$track/land_ice_segments/h_li"][1:step:end]::Vector{Float32}
+    zu = file["$track/land_ice_segments/h_li_sigma"][1:step:end]::Vector{Float32}
+    x = file["$track/land_ice_segments/longitude"][1:step:end]::Vector{Float64}
+    y = file["$track/land_ice_segments/latitude"][1:step:end]::Vector{Float64}
+    t = file["$track/land_ice_segments/delta_time"][1:step:end]::Vector{Float64}
+    q = file["$track/land_ice_segments/atl06_quality_summary"][1:step:end]::Vector{Int8}
+    dem = file["$track/land_ice_segments/dem/dem_h"][1:step:end]::Vector{Float32}
+    times = unix2datetime.(t .+ t_offset)
+
+    nt = (;
+        x = x,
+        y = y,
+        z = z,
+        u = zu,
+        t = times,
+        q = q,
+        track = Fill(track, length(times)),
+        power = Fill(power, length(times)),
+        reference = dem,
+    )
+    return nt
+end

--- a/src/SpaceLiDAR.jl
+++ b/src/SpaceLiDAR.jl
@@ -3,7 +3,8 @@ module SpaceLiDAR
 using Dates
 using CategoricalArrays
 using FillArrays
-using GeoDataFrames; const GDF = GeoDataFrames
+using GeoDataFrames
+const GDF = GeoDataFrames
 using HDF5
 
 include("granule.jl")
@@ -17,6 +18,7 @@ include("GEDI/GEDI.jl")
 include("GEDI/L2A.jl")
 include("ICESat-2/ICESat-2.jl")
 include("ICESat-2/ATL03.jl")
+include("ICESat-2/ATL06.jl")
 include("ICESat-2/ATL08.jl")
 include("ICESat-2/ATL12.jl")
 include("ICESat/ICESat.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -94,10 +94,10 @@ download_artifact(v"0.1", "GLAH14_634_1102_001_0071_0_01_0001.H5")
         g6 = SpaceLiDAR.granule_from_file(fn6)
         points = SpaceLiDAR.points(g6, step = 1000)
         @test length(points) == 6
-        @test length(points[1].z) == 34
+        @test length(points[1].height) == 34
         df = reduce(vcat, GeoDataFrames.DataFrame.(points))
-        @test minimum(df.t) == Dates.DateTime("2022-04-04T10:43:41.629")
-        @test all(in.(df.trackid, Ref(1:6)))
+        @test minimum(df.datetime) == Dates.DateTime("2022-04-04T10:43:41.629")
+        @test all(in.(df.detector_id, Ref(1:6)))
     end
     @testset "ATL08" begin
         fn8 = joinpath(@__DIR__, "data/ATL08_20201121151145_08920913_005_01.h5")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -93,8 +93,7 @@ download_artifact(v"0.1", "GLAH14_634_1102_001_0071_0_01_0001.H5")
         g6 = SpaceLiDAR.granule_from_file(fn6)
         points = SpaceLiDAR.points(g6, step = 1000)
         @test length(points) == 6
-        lines = SpaceLiDAR.lines(g6, step = 1000)
-        @test length(lines) == 6
+        @test length(points[1].z) == 34
     end
     @testset "ATL08" begin
         fn8 = joinpath(@__DIR__, "data/ATL08_20201121151145_08920913_005_01.h5")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -20,6 +20,7 @@ function download_artifact(version, source_filename)
 end
 
 download_artifact(v"0.2", "ATL03_20201121151145_08920913_005_01.h5")
+download_artifact(v"0.2", "ATL06_20220404104324_01881512_005_01.h5")
 download_artifact(v"0.2", "ATL08_20201121151145_08920913_005_01.h5")
 download_artifact(
     v"0.1",
@@ -55,6 +56,13 @@ download_artifact(v"0.1", "GLAH14_634_1102_001_0071_0_01_0001.H5")
         ) > 0
         @test length(
             find(
+                :ICESat2,
+                "ATL06",
+                (min_x = 4.0, min_y = 40.0, max_x = 5.0, max_y = 50.0),
+            ),
+        ) > 0
+        @test length(
+            find(
                 :GEDI,
                 "GEDI02_A",
                 (min_x = 4.0, min_y = 40.0, max_x = 5.0, max_y = 50.0),
@@ -79,6 +87,14 @@ download_artifact(v"0.1", "GLAH14_634_1102_001_0071_0_01_0001.H5")
         lines = SpaceLiDAR.lines(g3, step = 1000)
         @test length(lines) == 6
         SpaceLiDAR.classify(g3)
+    end
+    @testset "ATL06" begin
+        fn6 = joinpath(@__DIR__, "data/ATL06_20220404104324_01881512_005_01.h5")
+        g6 = SpaceLiDAR.granule_from_file(fn6)
+        points = SpaceLiDAR.points(g6, step = 1000)
+        @test length(points) == 6
+        lines = SpaceLiDAR.lines(g6, step = 1000)
+        @test length(lines) == 6
     end
     @testset "ATL08" begin
         fn8 = joinpath(@__DIR__, "data/ATL08_20201121151145_08920913_005_01.h5")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 using SpaceLiDAR
 using Test
 using LazIO
+using Dates
 using Distances
 import Downloads
 using Random
@@ -94,6 +95,9 @@ download_artifact(v"0.1", "GLAH14_634_1102_001_0071_0_01_0001.H5")
         points = SpaceLiDAR.points(g6, step = 1000)
         @test length(points) == 6
         @test length(points[1].z) == 34
+        df = reduce(vcat, GeoDataFrames.DataFrame.(points))
+        @test minimum(df.t) == Dates.DateTime("2022-04-04T10:43:41.629")
+        @test all(in.(df.trackid, Ref(1:6)))
     end
     @testset "ATL08" begin
         fn8 = joinpath(@__DIR__, "data/ATL08_20201121151145_08920913_005_01.h5")


### PR DESCRIPTION
Fixes #13 
@alex-s-gardner

```julia
julia> using SpaceLiDAR
julia> fn = "~/Downloads/ATL06_20220404104324_01881512_005_01.h5"
julia> g = SpaceLiDAR.granule_from_file(fn)
SpaceLiDAR.ICESat2_Granule{:ATL06}("ATL06_20220404104324_01881512_005_01.h5", "/Users/evetion/Downloads/ATL06_20220404104324_01881512_005_01.h5", (x_min = 0.0,), (type = :ATL06, date = Dates.DateTime("2022-04-04T10:43:24"), rgt = 188, cycle = 15, segment = 12, version = 5, revision = 1, ascending = true, descending = false))
julia> df = reduce(vcat, DataFrame.(points(g)))
203776×10 DataFrame
    Row │ x         y         z          u           t                        q     track   power   trackid  reference
        │ Float64   Float64   Float32    Float32     DateTime                 Int8  String  String  Int8     Float32
────────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────
      1 │ -105.221  -79.0058  1752.19    0.0111486   2022-04-04T10:43:41.664     0  gt1l    strong        1  1752.18
      2 │ -105.221  -79.0056  1752.23    0.0122074   2022-04-04T10:43:41.667     0  gt1l    strong        1  1752.17
      3 │ -105.221  -79.0054  1752.24    0.0111412   2022-04-04T10:43:41.669     0  gt1l    strong        1  1752.17
      4 │ -105.222  -79.0052  1752.19    0.00908957  2022-04-04T10:43:41.672     0  gt1l    strong        1  1752.17
      5 │ -105.222  -79.0051  1752.16    0.00937234  2022-04-04T10:43:41.675     0  gt1l    strong        1  1752.18
      6 │ -105.222  -79.0049  1752.16    0.00966735  2022-04-04T10:43:41.678     0  gt1l    strong        1  1752.19
      7 │ -105.222  -79.0047  1752.16    0.00983945  2022-04-04T10:43:41.681     0  gt1l    strong        1  1752.2
```

The `time_coverage_start` is in the granule filename, `g.date` in the above example. ~`atlas_spot_number` is not directly available, but `points(g)` gives you 6 tracks in order so it could be enumerated. I'm not sure why you need the number, but the beam strength is already provided in the above example.~