### PR TITLE
Reduce allocations and a bit of memory.

### DIFF
--- a/src/GEDI/L2A.jl
+++ b/src/GEDI/L2A.jl
@@ -103,8 +103,8 @@ function points(
                 start = start_grd
                 stop = stop_grd
             else
-                start = minimum([start_grd, start_can])
-                stop = maximum([stop_grd, stop_can])
+                start = min(start_grd, start_can)
+                stop = max(stop_grd, stop_can)
             end
 
         elseif ground
@@ -368,9 +368,9 @@ function bounds(granule::GEDI_Granule)
     HDF5.h5open(granule.url, "r") do file
         for track ∈ gedi_tracks
             if haskey(file, track)
-                group = open_dataset(file, track)
-                min_x, max_x = extrema(open_dataset(group, "lon_lowestmode"))
-                min_y, max_y = extrema(open_dataset(group, "lat_lowestmode"))
+                group = open_group(file, track)
+                min_x, max_x = extrema(read_dataset(group, "lon_lowestmode"))
+                min_y, max_y = extrema(read_dataset(group, "lat_lowestmode"))
                 min_xs = min(min_xs, min_x)
                 min_ys = min(min_ys, min_y)
                 max_xs = max(max_xs, max_x)

--- a/src/ICESat-2/ATL03.jl
+++ b/src/ICESat-2/ATL03.jl
@@ -239,18 +239,6 @@ function classify(
     dfs
 end
 
-struct ClassifyATL03
-    atl03::ICESat2_Granule{:ATL03}
-    atl08::ICESat2_Granule{:ATL08}
-end
-
-"""
-    classify(::ClassifyATL03)
-
-Used internally when called from DataFrame(::ClassifyATL03).
-"""
-classify(gg::ClassifyATL03; kwargs...) = classify(gg.atl03, gg.atl08; kwargs...)
-
 
 function create_mapping(dfsegment, unique_segments)
     index_map = Dict{Int64,Int64}()

--- a/src/ICESat-2/ATL03.jl
+++ b/src/ICESat-2/ATL03.jl
@@ -39,10 +39,10 @@ function points(
     end
     nts = Vector{NamedTuple}()
     HDF5.h5open(granule.url, "r") do file
-        t_offset = file["ancillary_data/atlas_sdp_gps_epoch"][1]::Float64 + gps_offset
+        t_offset = open_dataset(file, "ancillary_data/atlas_sdp_gps_epoch")[1]::Float64 + gps_offset
 
         for track ∈ tracks
-            if in(track, keys(file)) && in("heights", keys(file[track]))
+            if haskey(file, track) && haskey(open_group(file, track), "heights")
                 track_nt = points(granule, file, track, t_offset, step, bbox)
                 if !isempty(track_nt.height)
                     track_nt.height[track_nt.height.==fill_value] .= NaN
@@ -70,10 +70,11 @@ function lines(
     end
     nts = Vector{NamedTuple}()
     HDF5.h5open(granule.url, "r") do file
-        t_offset = read(file, "ancillary_data/atlas_sdp_gps_epoch")[1]::Float64 + gps_offset
+        t_offset = open_dataset(file, "ancillary_data/atlas_sdp_gps_epoch")[1]::Float64 + gps_offset
 
         for track ∈ tracks
-            if in(track, keys(file)) && in("heights", keys(file[track]))
+            if haskey(file, track) && haskey(open_group(file, track), "heights")
+
                 track_df = points(granule, file, track, t_offset, step, bbox)
                 line = Line(track_df.longitude, track_df.latitude, Float64.(track_df.height))
                 i = div(length(track_df.datetime), 2) + 1
@@ -101,9 +102,10 @@ function points(
     bbox::Union{Nothing,Extent} = nothing,
 )
 
+    group = open_group(file, track)
     if !isnothing(bbox)
-        x = file["$track/heights/lon_ph"][:]::Vector{Float64}
-        y = file["$track/heights/lat_ph"][:]::Vector{Float64}
+        x = read_dataset(group, "heights/lon_ph")::Vector{Float64}
+        y = read_dataset(group, "heights/lat_ph")::Vector{Float64}
 
         # find index of points inside of bbox
         ind = (x .> bbox.X[1]) .& (y .> bbox.Y[1]) .& (x .< bbox.X[2]) .& (y .< bbox.Y[2])
@@ -112,8 +114,8 @@ function points(
 
         if isnothing(start)
             @warn "no data found within bbox of track $track in $(file.filename)"
-            spot_number = attrs(file["$track"])["atlas_spot_number"]::String
-            atlas_beam_type = attrs(file["$track"])["atlas_beam_type"]::String
+            spot_number = read_attribute(group, "atlas_spot_number")::String
+            atlas_beam_type = read_attribute(group, "atlas_beam_type")::String
 
             nt = (
                 longitude = Float64[],
@@ -138,39 +140,39 @@ function points(
         y = y[start:step:stop]
     else
         start = 1
-        stop = length(file["$track/heights/lon_ph"])
-        x = file["$track/heights/lon_ph"][start:step:stop]::Vector{Float64}
-        y = file["$track/heights/lat_ph"][start:step:stop]::Vector{Float64}
+        stop = length(open_dataset(group, "heights/lon_ph"))
+        x = open_dataset(group, "heights/lon_ph")[start:step:stop]::Vector{Float64}
+        y = open_dataset(group, "heights/lat_ph")[start:step:stop]::Vector{Float64}
     end
 
-    height = file["$track/heights/h_ph"][start:step:stop]::Vector{Float32}
-    datetime = file["$track/heights/delta_time"][start:step:stop]::Vector{Float64}
+    height = open_dataset(group, "heights/h_ph")[start:step:stop]::Vector{Float32}
+    datetime = open_dataset(group, "heights/delta_time")[start:step:stop]::Vector{Float64}
 
     # NOT SURE WHY ONLY THE FIRST CONFIDENCE FLAG WAS CHOSEN.. MIGHT NEED TO REVISIT
-    signal_confidence = file["$track/heights/signal_conf_ph"][1, start:step:stop]::Vector{Int8}
-    quality = file["$track/heights/quality_ph"][start:step:stop]::Vector{Int8}
+    signal_confidence = open_dataset(group, "heights/signal_conf_ph")[1, start:step:stop]::Vector{Int8}
+    quality = open_dataset(group, "heights/quality_ph")[start:step:stop]::Vector{Int8}
 
     # Mapping between segment and photon
-    seg_cnt = file["$track/geolocation/segment_ph_cnt"][:]::Vector{Int32}
+    seg_cnt = read(open_dataset(group, "geolocation/segment_ph_cnt"))::Vector{Int32}
     ph_ind = count2index(seg_cnt)
     ph_ind = ph_ind[start:step:stop]
 
     # extract data posted at segment frequency and map to photon frequency
-    segment = file["$track/geolocation/segment_id"][:]::Vector{Int32}
-    segment = segment[ph_ind]
+    segment = read(open_dataset(group, "geolocation/segment_id"))[ph_ind]::Vector{Int32}
+    # segment = segment[ph_ind]
 
-    sun_angle = file["$track/geolocation/solar_elevation"][:]::Vector{Float32}
-    sun_angle = sun_angle[ph_ind]
+    sun_angle = read(open_dataset(group, "geolocation/solar_elevation"))[ph_ind]::Vector{Float32}
+    # sun_angle = sun_angle[ph_ind]
 
-    uncertainty = file["$track/geolocation/sigma_h"][:]::Vector{Float32}
-    uncertainty = uncertainty[ph_ind]
+    uncertainty = read(open_dataset(group, "geolocation/sigma_h"))[ph_ind]::Vector{Float32}
+    # uncertainty = uncertainty[ph_ind]
 
-    height_ref = file["$track/geophys_corr/dem_h"][:]::Vector{Float32}
-    height_ref = height_ref[ph_ind]
+    height_ref = read(open_dataset(group, "geophys_corr/dem_h"))[ph_ind]::Vector{Float32}
+    # height_ref = height_ref[ph_ind]
 
     # extract attributes
-    spot_number = attrs(file["$track"])["atlas_spot_number"]::String
-    atlas_beam_type = attrs(file["$track"])["atlas_beam_type"]::String
+    spot_number = read_attribute(group, "atlas_spot_number")::String
+    atlas_beam_type = read_attribute(group, "atlas_beam_type")::String
 
     # convert from unix time to julia date time
     datetime = unix2datetime.(datetime .+ t_offset)
@@ -193,6 +195,7 @@ function points(
     return nt
 end
 
+
 """
     classify(granule::ICESat2_Granule{:ATL03}, atl08::Union{ICESat2_Granule{:ATL08},Nothing} = nothing, tracks = icesat2_tracks)
 
@@ -210,10 +213,10 @@ function classify(
 
     dfs = Vector{NamedTuple}()
     HDF5.h5open(granule.url, "r") do file
-        t_offset = read(file, "ancillary_data/atlas_sdp_gps_epoch")[1]::Float64 + gps_offset
+        t_offset = open_dataset(file, "ancillary_data/atlas_sdp_gps_epoch")[1]::Float64 + gps_offset
 
         for track ∈ tracks
-            if in(track, keys(file)) && in("heights", keys(file[track]))
+            if haskey(file, track) && haskey(open_group(file, track), "heights")
                 track_df = points(granule, file, track, t_offset)
 
                 mapping = atl03_mapping(atl08, track)
@@ -235,6 +238,19 @@ function classify(
     end
     dfs
 end
+
+struct ClassifyATL03
+    atl03::ICESat2_Granule{:ATL03}
+    atl08::ICESat2_Granule{:ATL08}
+end
+
+"""
+    classify(::ClassifyATL03)
+
+Used internally when called from DataFrame(::ClassifyATL03).
+"""
+classify(gg::ClassifyATL03; kwargs...) = classify(gg.atl03, gg.atl08; kwargs...)
+
 
 function create_mapping(dfsegment, unique_segments)
     index_map = Dict{Int64,Int64}()

--- a/src/ICESat/GLAH14.jl
+++ b/src/ICESat/GLAH14.jl
@@ -38,9 +38,9 @@ function points(
     end
     HDF5.h5open(granule.url, "r") do file
         if !isnothing(bbox)
-            x = file["Data_40HZ/Geolocation/d_lon"][:]::Vector{Float64}
+            x = read_dataset(file, "Data_40HZ/Geolocation/d_lon")::Vector{Float64}
             x[x.>180] .= x[x.>180] .- 360.0  # translate from 0 - 360
-            y = file["Data_40HZ/Geolocation/d_lat"][:]::Vector{Float64}
+            y = read_dataset(file, "Data_40HZ/Geolocation/d_lat")::Vector{Float64}
 
             # find index of points inside of bbox
             ind = (x .> bbox.X[1]) .& (y .> bbox.Y[1]) .& (x .< bbox.X[2]) .& (y .< bbox.Y[2])
@@ -71,15 +71,15 @@ function points(
             y = y[start:step:stop]
         else
             start = 1
-            stop = length(file["Data_40HZ/Geolocation/d_lon"])
-            x = file["Data_40HZ/Geolocation/d_lon"][start:step:stop]::Vector{Float64}
-            y = file["Data_40HZ/Geolocation/d_lat"][start:step:stop]::Vector{Float64}
+            stop = length(open_dataset(file, "Data_40HZ/Geolocation/d_lon"))
+            x = read_dataset(file, "Data_40HZ/Geolocation/d_lon")[start:step:stop]::Vector{Float64}
+            y = read_dataset(file, "Data_40HZ/Geolocation/d_lat")[start:step:stop]::Vector{Float64}
         end
 
         valid = (x .!= icesat_fill) .& (y .!= icesat_fill)
-        height = file["Data_40HZ/Elevation_Surfaces/d_elev"][start:step:stop]::Vector{Float64}
+        height = read_dataset(file, "Data_40HZ/Elevation_Surfaces/d_elev")[start:step:stop]::Vector{Float64}
         valid .&= height .!= icesat_fill
-        height_correction = file["Data_40HZ/Elevation_Corrections/d_satElevCorr"][start:step:stop]::Vector{Float64}
+        height_correction = read_dataset(file, "Data_40HZ/Elevation_Corrections/d_satElevCorr")[start:step:stop]::Vector{Float64}
         valid .&= (height_correction .!= icesat_fill)
         height .+= height_correction
 
@@ -88,15 +88,15 @@ function points(
         height = height[valid]
         height_correction = height_correction[valid]
 
-        datetime = file["Data_40HZ/DS_UTCTime_40"][start:step:stop][valid]::Vector{Float64}
-        quality = file["Data_40HZ/Quality/elev_use_flg"][start:step:stop][valid]::Vector{Int8}
-        clouds = file["Data_40HZ/Elevation_Flags/elv_cloud_flg"][start:step:stop][valid]::Vector{Int8}
-        sat_corr_flag = file["Data_40HZ/Quality/sat_corr_flg"][start:step:stop][valid]::Vector{Int8}
-        sigma_att_flg = file["Data_40HZ/Quality/sigma_att_flg"][start:step:stop][valid]::Vector{Int8}
-        ref_flag = file["Data_40HZ/Reflectivity/d_reflctUC"][start:step:stop][valid]::Vector{Float64}
-        gain_value = file["Data_40HZ/Waveform/i_gval_rcv"][start:step:stop][valid]::Vector{Int32}
-        i_numPk = file["Data_40HZ/Waveform/i_numPk"][start:step:stop][valid]::Vector{Int32}
-        height_ref = file["Data_40HZ/Geophysical/d_DEM_elv"][start:step:stop][valid]::Vector{Float64}
+        datetime = read_dataset(file, "Data_40HZ/DS_UTCTime_40")[start:step:stop][valid]::Vector{Float64}
+        quality = read_dataset(file, "Data_40HZ/Quality/elev_use_flg")[start:step:stop][valid]::Vector{Int8}
+        clouds = read_dataset(file, "Data_40HZ/Elevation_Flags/elv_cloud_flg")[start:step:stop][valid]::Vector{Int8}
+        sat_corr_flag = read_dataset(file, "Data_40HZ/Quality/sat_corr_flg")[start:step:stop][valid]::Vector{Int8}
+        sigma_att_flg = read_dataset(file, "Data_40HZ/Quality/sigma_att_flg")[start:step:stop][valid]::Vector{Int8}
+        ref_flag = read_dataset(file, "Data_40HZ/Reflectivity/d_reflctUC")[start:step:stop][valid]::Vector{Float64}
+        gain_value = read_dataset(file, "Data_40HZ/Waveform/i_gval_rcv")[start:step:stop][valid]::Vector{Int32}
+        i_numPk = read_dataset(file, "Data_40HZ/Waveform/i_numPk")[start:step:stop][valid]::Vector{Int32}
+        height_ref = read_dataset(file, "Data_40HZ/Geophysical/d_DEM_elv")[start:step:stop][valid]::Vector{Float64}
 
         # SHOULD WE FILL WITH NAN OR MISSINGS ?
         height_ref[height_ref.==icesat_fill] .= NaN

--- a/src/table.jl
+++ b/src/table.jl
@@ -3,6 +3,11 @@ Tables.columnaccess(::Type{<:SpaceLiDAR.Granule}) = true
 Tables.partitions(g::SpaceLiDAR.Granule) = points(g)
 Tables.columns(g::SpaceLiDAR.Granule) = Tables.CopiedColumns(joinpartitions(g))
 
+Tables.istable(::Type{<:SpaceLiDAR.ClassifyATL03}) = true
+Tables.columnaccess(::Type{<:SpaceLiDAR.ClassifyATL03}) = true
+Tables.partitions(g::SpaceLiDAR.ClassifyATL03) = classify(g)
+Tables.columns(g::SpaceLiDAR.ClassifyATL03) = Tables.CopiedColumns(joinpartitions(g))
+
 # ICESat has no beams, so no need for partitions
 Tables.istable(::Type{<:SpaceLiDAR.ICESat_Granule}) = true
 Tables.columnaccess(::Type{<:SpaceLiDAR.ICESat_Granule}) = true

--- a/src/table.jl
+++ b/src/table.jl
@@ -3,11 +3,6 @@ Tables.columnaccess(::Type{<:SpaceLiDAR.Granule}) = true
 Tables.partitions(g::SpaceLiDAR.Granule) = points(g)
 Tables.columns(g::SpaceLiDAR.Granule) = Tables.CopiedColumns(joinpartitions(g))
 
-Tables.istable(::Type{<:SpaceLiDAR.ClassifyATL03}) = true
-Tables.columnaccess(::Type{<:SpaceLiDAR.ClassifyATL03}) = true
-Tables.partitions(g::SpaceLiDAR.ClassifyATL03) = classify(g)
-Tables.columns(g::SpaceLiDAR.ClassifyATL03) = Tables.CopiedColumns(joinpartitions(g))
-
 # ICESat has no beams, so no need for partitions
 Tables.istable(::Type{<:SpaceLiDAR.ICESat_Granule}) = true
 Tables.columnaccess(::Type{<:SpaceLiDAR.ICESat_Granule}) = true

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -173,10 +173,6 @@ empty_bbox = (min_x = 4.0, min_y = 40.0, max_x = 5.0, max_y = 50.0)
         @test df.classification isa CategoricalVector{String,Int8}
         SL.materialize!(df)
         @test df.classification isa Vector{String}
-
-        C = SL.ClassifyATL03(g, g8)
-        dfc = DataFrame(C)
-        @test isequal(df, dfc)
     end
 
     @testset "ATL06" begin


### PR DESCRIPTION
Apart from reducing the overall allocations and reducing some memory usage from an overuse of `attrs` and `keys`, all which (sadly) has a negligible impact on performance, I've also added a way of getting a DataFrame of a classified ATL03 pointset without extra allocations (as you would currently get from classify, having to go with `reduce(vcat, DataFrame.())`

```julia
struct ClassifyATL03
    atl03::ICESat2_Granule{:ATL03}
    atl08::ICESat2_Granule{:ATL08}
end
classify(::ClassifyATL03) == classify(::ICESat2_Granule{:ATL03}, ::ICESat2_Granule{:ATL08})
DataFrame(::ClassifyATL03)  # like DataFrame(::ICESat2_Granule)
```

I'm not yet sure about the name `ClassifyATL03`, but this lazy way of combining granules/operations seems useful. In the end, like icepyx or DataFrames Groupby, one could have Query structs that detail some (lazy) operations.

Also added test for all DataFrame(granule) calls for each data product.
