### PR TITLE
add "id" to seach + test

### DIFF
--- a/src/search.jl
+++ b/src/search.jl
@@ -28,6 +28,7 @@ function search(
     version::Int = 2,
     before::Union{Nothing,DateTime} = nothing,
     after::Union{Nothing,DateTime} = nothing,
+    id::Union{Nothing,String}=nothing,
     provider::String = "LPDAAC_ECS",
 )::Vector{GEDI_Granule}
     startswith(string(product), prefix(m)) || throw(ArgumentError("Wrong product $product for $(mission(m)) mission."))
@@ -37,7 +38,7 @@ function search(
     end
 
     granules =
-        earthdata_search(short_name = string(product), bounding_box = extent, version = version, provider = provider, before = before, after = after)
+        earthdata_search(short_name = string(product), bounding_box = extent, version = version, provider = provider, before = before, after = after, id = id)
     length(granules) == 0 && @warn "No granules found, did you specify the correct parameters, such as version?"
     filter!(g -> !isnothing(g.https_url), granules)
     map(
@@ -58,6 +59,7 @@ function search(
     version::Int = 6,
     before::Union{Nothing,DateTime} = nothing,
     after::Union{Nothing,DateTime} = nothing,
+    id::Union{Nothing,String}=nothing,
     s3::Bool = false,
     provider::String = s3 ? "NSIDC_CPRD" : "NSIDC_ECS",
 )::Vector{ICESat2_Granule}
@@ -68,7 +70,7 @@ function search(
     end
 
     granules =
-        earthdata_search(short_name = string(product), bounding_box = extent, version = version, provider = provider, before = before, after = after)
+        earthdata_search(short_name = string(product), bounding_box = extent, version = version, provider = provider, before = before, after = after, id = id)
     length(granules) == 0 && @warn "No granules found, did you specify the correct parameters, such as version?"
     s3 ? filter!(g -> !isnothing(g.s3_url), granules) : filter!(g -> !isnothing(g.https_url), granules)
     map(
@@ -89,6 +91,7 @@ function search(
     version::Int = 34,
     before::Union{Nothing,DateTime} = nothing,
     after::Union{Nothing,DateTime} = nothing,
+    id::Union{Nothing,String}=nothing,
     s3::Bool = false,
     provider::String = s3 ? "NSIDC_CPRD" : "NSIDC_ECS",
 )::Vector{ICESat_Granule}
@@ -99,7 +102,7 @@ function search(
     end
 
     granules =
-        earthdata_search(short_name = string(product), bounding_box = extent, version = version, provider = provider, before = before, after = after)
+        earthdata_search(short_name = string(product), bounding_box = extent, version = version, provider = provider, before = before, after = after, id = id)
     length(granules) == 0 && @warn "No granules found, did you specify the correct parameters, such as version?"
     s3 ? filter!(g -> !isnothing(g.s3_url), granules) : filter!(g -> !isnothing(g.https_url), granules)
     map(
@@ -214,6 +217,7 @@ function earthdata_search(;
     provider::Union{Nothing,String} = "NSIDC_CPRD",
     before::Union{Nothing,DateTime} = nothing,
     after::Union{Nothing,DateTime} = nothing,
+    id::Union{Nothing,String} = nothing,
     all_pages::Bool = true,
     page_size = 2000,
     page_num = 1,  # unused
@@ -232,6 +236,10 @@ function earthdata_search(;
 
     if !isnothing(before) || !isnothing(after)
         q["temporal"] = "$(isnothing(after) ? "" : after),$(isnothing(before) ? "" : before)"
+    end
+
+    if !isnothing(id)
+    q["producer_granule_id"] = id
     end
 
     qurl = umm ? earthdata_url : replace(earthdata_url, "umm_json_v1_6_4" => "json")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -78,6 +78,9 @@ empty_extent = convert(Extent, empty_bbox)
         @test length(granules) > 0
         @test length(granules[1].polygons) > 0
 
+        id = "GEDI02_A_2023003040347_O22988_03_T06105_02_003_02_V002.h5";
+        @test = length(search(:GEDI, :GEDI02_A; version = 2, id = id)) == 1
+
         @test_throws ArgumentError find(:ICESat2, "GLAH14")
         @test_throws ArgumentError find(:Foo, "GLAH14")
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -79,7 +79,7 @@ empty_extent = convert(Extent, empty_bbox)
         @test length(granules[1].polygons) > 0
 
         id = "GEDI02_A_2023003040347_O22988_03_T06105_02_003_02_V002.h5";
-        @test = length(search(:GEDI, :GEDI02_A; version = 2, id = id)) == 1
+        @test length(search(:GEDI, :GEDI02_A; version = 2, id = id)) == 1
 
         @test_throws ArgumentError find(:ICESat2, "GLAH14")
         @test_throws ArgumentError find(:Foo, "GLAH14")


### PR DESCRIPTION
This allow you to search for the granule that matched the granule id.

Helpful for finding url to original file... I need this when a .h5 is found to be corrupt and it needs to be downloaded again. 