### PR TITLE
Search for groups of granules and convert them.

### DIFF
--- a/src/ICESat-2/ICESat-2.jl
+++ b/src/ICESat-2/ICESat-2.jl
@@ -129,8 +129,8 @@ Converts the granule `g` to the product `product`, by guessing the correct name.
 """
 function Base.convert(product::Symbol, g::ICESat2_Granule{T}) where {T}
     g = ICESat2_Granule{product}(
-        replace(replace(g.id, String(T) => String(product)), lowercase(String(T)) => lowercase(String(product))),
-        replace(replace(g.url, String(T) => String(product)), lowercase(String(T)) => lowercase(String(product))),
+        _convert(g.id, T, product),
+        _convert(g.url, T, product),
         g.info,
         g.polygons,
     )
@@ -146,6 +146,9 @@ function Base.convert(product::Symbol, g::ICESat2_Granule{T}) where {T}
     g
 end
 
+function _convert(s::AbstractString, old::Symbol, new::Symbol)
+    replace(replace(s, String(old) => String(new)), lowercase(String(old)) => lowercase(String(new)))
+end
 
 """
     info(g::ICESat2_Granule)

--- a/src/granule.jl
+++ b/src/granule.jl
@@ -217,10 +217,10 @@ function _sync!(granules, folder, all; kwargs...)
     isempty(granules) && error("No granules found in provided folder(s).")
     g = first(granules)
     ngranules = if length(granules) == 0 || !haskey(info(granules[end]), :date) || all
-        Set(search(g; kwargs...))
+        Set(search(mission(g), sproduct(g); kwargs...))
     else
         sort!(granules, by = x -> x.id)
-        Set(search(g; after = info(granules[end]).date, kwargs...))
+        Set(search(mission(g), sproduct(g); after = info(granules[end]).date, kwargs...))
     end
     setdiff!(ngranules, Set(granules))
     download!(collect(ngranules), folder)


### PR DESCRIPTION
Continuing from #78 

## Changes:
- (breaking for *unreleased* master branch) `search(granule)` now return a single granule only with the online url (previously did search based on the mission/product of the provided granule, yielding many results)

## Adds:
- `search(granules)`, returning online urls for multiple granules
- `search(granule, product)`, returns a single (online) granule for the given product, with the rest derived from the original granule
- `search(granules, product)`, same as above for multiple granules.

## Rationale
Local granules can be corrupt, so retrieving the online url to redownload is very useful. On top of that, I tend to want both the ATL03 and ATL08 versions of a granule. At the moment this requires multiple searches (with the same bbox), but this yields slightly different results (ATL03 tends to yield more granules than ATL08). Now you can do `search(granules, :ATL03)` with a list of ATL08 granules.

Note that I changed the HTTP search method to POST to allow for a large body of ids, that otherwise don't fit as a single url (GET).

